### PR TITLE
Use HTTPS file source for this image

### DIFF
--- a/QualityRatings/DFWikiFunctions/extensions/DFDiagram/modules/ext.DFDiagram.js
+++ b/QualityRatings/DFWikiFunctions/extensions/DFDiagram/modules/ext.DFDiagram.js
@@ -1,5 +1,5 @@
 jQuery(function($){
-	Tileset.Font.loadFromURL('http://dwarffortresswiki.org/images/b/b7/Default_tileset_8x12.png').on('ready', function(evt, font){
+	Tileset.Font.loadFromURL('https://dwarffortresswiki.org/images/b/b7/Default_tileset_8x12.png').on('ready', function(evt, font){
 		$('.dfdiagram').each(function(i, e){
 			var frameList = $();
 			$(e).find('.dfdiagram-frame').each(function(i, e) {


### PR DESCRIPTION
Use HTTPS file source for this image, since the DFWiki is transitioning to serving all pages with HTTPS
